### PR TITLE
test: clean up lint issues

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from proxmox_mcp.client import api_request, format_response, get_client, _get_client
+from proxmox_mcp.client import api_request, format_response, _get_client
 
 
 class TestGetClient:
@@ -26,7 +26,7 @@ class TestGetClient:
         }
         with patch.dict("os.environ", env, clear=True), patch("proxmox_mcp.client.ProxmoxAPI") as mock_api:
             mock_api.return_value = MagicMock()
-            client = _get_client()
+            _get_client()
             mock_api.assert_called_once_with(
                 "10.0.0.1",
                 port=8006,
@@ -46,7 +46,7 @@ class TestGetClient:
         }
         with patch.dict("os.environ", env, clear=True), patch("proxmox_mcp.client.ProxmoxAPI") as mock_api:
             mock_api.return_value = MagicMock()
-            client = _get_client()
+            _get_client()
             mock_api.assert_called_once_with(
                 "10.0.0.1",
                 port=8006,
@@ -80,7 +80,6 @@ class TestGetClient:
         mod._client = None  # reset cache
         with patch.object(mod, "_get_client", return_value=mock):
             # Temporarily restore the real get_client to test caching
-            real_fn = mod.get_client
             try:
                 # Bypass autouse patch by calling the real implementation
                 def _real_get_client():
@@ -106,7 +105,7 @@ class TestApiRequest:
 
     def test_post_with_params(self, mock_proxmox_client):
         mock_proxmox_client.nodes.pve1.qemu.post.return_value = "UPID:pve1:..."
-        result = api_request("post", "/nodes/pve1/qemu", vmid=100, name="test")
+        api_request("post", "/nodes/pve1/qemu", vmid=100, name="test")
         mock_proxmox_client.nodes.pve1.qemu.post.assert_called_once_with(vmid=100, name="test")
 
     def test_rejects_unsupported_method(self):
@@ -121,8 +120,7 @@ class TestApiRequest:
     def test_deep_path(self, mock_proxmox_client):
         mock_proxmox_client.nodes.pve1.qemu.__getattr__("100").status.current.get.return_value = {"status": "running"}
         # MagicMock chains automatically
-        result = api_request("get", "/nodes/pve1/qemu/100/status/current")
-        assert result is not None
+        assert api_request("get", "/nodes/pve1/qemu/100/status/current") is not None
 
 
 class TestFormatResponse:

--- a/tests/test_management_tools.py
+++ b/tests/test_management_tools.py
@@ -1,8 +1,6 @@
 """Tests for cluster, access, storage, and other management tools."""
 
 import json
-import pytest
-from unittest.mock import MagicMock
 
 from proxmox_mcp.client import api_request, format_response
 
@@ -21,7 +19,7 @@ class TestClusterTools:
         mock_proxmox_client.cluster.resources.get.return_value = [
             {"type": "qemu", "vmid": 100, "name": "web", "status": "running"},
         ]
-        result = api_request("get", "/cluster/resources", type="vm")
+        api_request("get", "/cluster/resources", type="vm")
         mock_proxmox_client.cluster.resources.get.assert_called_once_with(type="vm")
 
     def test_get_next_vmid(self, mock_proxmox_client):

--- a/tests/test_node_tools.py
+++ b/tests/test_node_tools.py
@@ -1,10 +1,6 @@
 """Tests for node management tools."""
 
-import json
-import pytest
-from unittest.mock import MagicMock
-
-from proxmox_mcp.client import api_request, format_response
+from proxmox_mcp.client import api_request
 
 
 class TestNodeTools:

--- a/tests/test_vm_tools.py
+++ b/tests/test_vm_tools.py
@@ -1,10 +1,6 @@
 """Tests for QEMU VM and LXC container tools."""
 
-import json
-import pytest
-from unittest.mock import MagicMock
-
-from proxmox_mcp.client import api_request, format_response
+from proxmox_mcp.client import api_request
 
 
 class TestQemuTools:
@@ -28,7 +24,7 @@ class TestQemuTools:
 
     def test_create_vm(self, mock_proxmox_client):
         mock_proxmox_client.nodes.pve1.qemu.post.return_value = "UPID:pve1:00001234"
-        result = api_request("post", "/nodes/pve1/qemu", vmid=102, name="test-vm", memory=4096, cores=2)
+        api_request("post", "/nodes/pve1/qemu", vmid=102, name="test-vm", memory=4096, cores=2)
         mock_proxmox_client.nodes.pve1.qemu.post.assert_called_once_with(
             vmid=102, name="test-vm", memory=4096, cores=2
         )
@@ -60,7 +56,7 @@ class TestLxcTools:
 
     def test_create_container(self, mock_proxmox_client):
         mock_proxmox_client.nodes.pve1.lxc.post.return_value = "UPID:pve1:..."
-        result = api_request(
+        api_request(
             "post", "/nodes/pve1/lxc",
             vmid=201, hostname="test-ct", ostemplate="local:vztmpl/debian-12.tar.zst",
             memory=512, cores=1,


### PR DESCRIPTION
## Summary
- remove unused imports from test modules
- remove unused local variables while preserving existing assertions and API call checks
- make  pass on the full repo

## Verification
- .venv/bin/python -m flake8 src tests
- .venv/bin/python -m pytest tests -q
- .venv/bin/python -m mypy src/proxmox_mcp
- .venv/bin/python scripts/generate_tool_manifest.py --check
- git diff --check